### PR TITLE
Pin the revision of the BSP layer.

### DIFF
--- a/imx-5.15.71-2.2.2.xml
+++ b/imx-5.15.71-2.2.2.xml
@@ -28,7 +28,7 @@
 
   <project name="meta-imx" path="sources/meta-imx" remote="nxp-imx" revision="refs/tags/rel_imx_5.15.71_2.2.2" upstream="kirkstone-5.15.71-2.2.2"/>
   <project name="meta-tn-wifi" path="sources/meta-tn-wifi" remote="tn-bsp" revision="84f80aeeb629331777582da41e207ced62e97a81"/>
-  <project name="meta-tn-imx-bsp" path="sources/meta-tn-imx-bsp" remote="tn-bsp" revision="kirkstone_5.15.71-2.2.0-stable">
+  <project name="meta-tn-imx-bsp" path="sources/meta-tn-imx-bsp" remote="tn-bsp" revision="1ae9d78e6dabeabf9cb914274a79347a608c141b" upstream="kirkstone_5.15.71-2.2.0-stable">
     <linkfile src="tools/tn-setup-release.sh" dest="tn-setup-release.sh"/>
     <linkfile src="README" dest="README-TechNexion-BSP"/>
   </project>


### PR DESCRIPTION
Stable manifests should use fixed commit IDs rather than branches as revisions. Otherwise a manifest will not always pull in the same set of sources. This PR fixes the problem in imx-5.15.71-2.2.2.xml (though not the older manifests) by pinning the revision of the Technexion BSP layer. All the other layers were already using specific commits rather than branches.